### PR TITLE
DSB::Path::Tiny

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,6 +17,7 @@ Git::NextVersion_version_regexp = ^Data-Stream-Bulk-(.+)$
 Moose = 0.90
 namespace::clean = 0
 Path::Class = 0
+Path::Tiny = 0
 Sub::Exporter = 0
 
 [Prereqs / TestRequires]

--- a/lib/Data/Stream/Bulk/Path/Tiny.pm
+++ b/lib/Data/Stream/Bulk/Path/Tiny.pm
@@ -1,0 +1,193 @@
+package Data::Stream::Bulk::Path::Tiny;
+use Moose;
+# ABSTRACT: L<Path::Tiny> traversal
+
+use Carp qw(croak);
+use IO::Dir;
+use Path::Tiny;
+
+use namespace::clean -except => 'meta';
+
+with qw(Data::Stream::Bulk);
+
+has dir => (
+	isa => "Path::Tiny",
+	is  => "ro",
+	required => 1,
+);
+
+has depth_first => (
+	isa => "Bool",
+	is  => "rw",
+	default => 1,
+);
+
+has only_files => (
+	isa => "Bool",
+	is  => "ro",
+);
+
+has chunk_size => (
+	isa => "Int",
+	is  => "rw",
+	default => 250,
+);
+
+has _stack => (
+	isa => "ArrayRef",
+	is  => "ro",
+	default => sub { [] },
+);
+
+has _queue => (
+	isa => "ArrayRef",
+	is  => "ro",
+	lazy => 1,
+	default => sub {
+		my $self = shift;
+		return [ $self->dir ],
+	},
+);
+
+sub is_done {
+	my $self = shift;
+	return (
+		@{ $self->_stack } == 0
+			and
+		@{ $self->_queue } == 0
+	);
+}
+
+sub next {
+	my $self = shift;
+
+	my $queue = $self->_queue;
+	my $stack = $self->_stack;
+
+	my $depth_first = $self->depth_first;
+	my $only_files  = $self->only_files;
+	my $chunk_size  = $self->chunk_size;
+
+	my @ret;
+
+	{
+		outer: while ( @$stack ) {
+			my $frame = $stack->[-1];
+
+			my ( $dh, $parent ) = @$frame;
+
+			while ( defined(my $entry = $dh->read) ) {
+				next if $entry eq '.' || $entry eq '..';
+
+				my $path = $parent->child($entry);
+
+				if ( $path->is_dir ) {
+					if ( $depth_first ) {
+						unshift @$queue, $path;
+					} else {
+						push @$queue, $path;
+					}
+
+					last outer;
+				} else {
+					push @ret, $path;
+					return \@ret if @ret >= $chunk_size;
+				}
+			}
+
+			# we're done reading this dir
+			pop @$stack;
+		}
+
+		if ( @$queue ) {
+			my $dir = shift @$queue;
+			my $dh = IO::Dir->new($dir) ||
+				croak("Can't open directory $dir: $!");
+
+			if ( $depth_first ) {
+				push @$stack, [ $dh, $dir ];
+			} else {
+				unshift @$stack, [ $dh, $dir ];
+			}
+
+			unless ( $only_files ) {
+				push @ret, $dir;
+				return \@ret if @ret >= $chunk_size;
+			}
+
+			redo;
+		}
+	}
+
+	return unless @ret;
+	return \@ret;
+}
+
+
+__PACKAGE__->meta->make_immutable;
+
+__PACKAGE__;
+
+__END__
+
+=pod
+
+=head1 SYNOPSIS
+
+	use Data::Stream::Bulk::Path::Tiny;
+	use Path::Tiny;
+
+	my $dir = Data::Stream::Bulk::Path::Tiny->new(
+		dir => path( ... ),
+	);
+
+=head1 DESCRIPTION
+
+This stream produces depth or breadth first traversal order recursion through
+L<Path::Tiny> objects.
+
+Items are read iteratively, and a stack of open directory handles is used to
+keep track of state.
+
+=head1 ATTRIBUTES
+
+=over 4
+
+=item chunk_size
+
+Defaults to 250.
+
+=item depth_first
+
+Chooses between depth first and breadth first traversal order.
+
+=item only_files
+
+If true only files will be returned in the output streams
+(no directories).
+
+=back
+
+=head1 METHODS
+
+=over 4
+
+=item is_done
+
+Returns true when no more files are left to iterate.
+
+=item next
+
+Returns the next chunk of L<Path::Tiny> objects
+
+=back
+
+=head1 SEE ALSO
+
+L<Path::Tiny>
+
+=head1 AUTHOR
+
+Sergey Romanov <sromanov@cpan.org>
+
+=cut

--- a/t/path_tiny.t
+++ b/t/path_tiny.t
@@ -1,0 +1,127 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Data::Stream::Bulk::Path::Tiny;
+
+use Path::Class qw(dir);
+use Path::Tiny qw(path);
+
+my $dist = path(__FILE__)->parent->parent;
+
+foreach my $dir ( $dist->child("t"), $dist->child("lib"), $dist ) {
+
+	{
+		my $paths = Data::Stream::Bulk::Path::Tiny->new(
+			dir => $dir,
+			chunk_size => 2,
+			depth_first => 0,
+		);
+
+		my $strings = $paths->filter(sub {[ grep { !/tmp/ } map { "$_" } @$_ ]});
+
+		my @rec;
+		my $pc_dir = dir($dir);
+		$pc_dir->recurse(
+			callback => sub { push @rec, path($_[0]) unless $_[0] =~ /tmp/ },
+			depthfirst => 0,
+			preorder => 1
+		);
+
+		ok( !$_->is_done, "not done" ) for $paths, $strings;
+
+		my @all = $strings->all;
+
+		ok( $_->is_done, "done" ) for $paths, $strings;
+
+		is_deeply(
+			[ sort @all ],
+			[ sort @rec ],
+			"breadth first traversal path set",
+		);
+
+		is_deeply(
+			\@all,
+			\@rec,
+			"breadth first traversal order",
+		);
+	}
+
+	{
+		my $paths = Data::Stream::Bulk::Path::Tiny->new(
+			dir => $dir,
+			chunk_size => 2,
+			depth_first => 1,
+		);
+
+		my $strings = $paths->filter(sub {[ grep { !/tmp/ } map { "$_" } @$_ ]});
+
+		my @rec;
+		my $pc_dir = dir($dir);
+		$pc_dir->recurse(
+			callback => sub { push @rec, path($_[0]) unless $_[0] =~ /tmp/ },
+			depthfirst => 1,
+			preorder => 1
+		);
+
+		ok( !$_->is_done, "not done" ) for $paths, $strings;
+
+		my @all = $strings->all;
+
+		ok( $_->is_done, "done" ) for $paths, $strings;
+
+		is_deeply(
+			[ sort @all ],
+			[ sort @rec ],
+			"depth first traversal path set",
+		);
+
+		is_deeply(
+			\@all,
+			\@rec,
+			"depth first traversal order",
+		);
+	}
+
+	{
+		my $paths = Data::Stream::Bulk::Path::Tiny->new(
+			dir => $dir,
+			chunk_size => 2,
+			depth_first => 0,
+			only_files => 1,
+		);
+
+		my $strings = $paths->filter(sub {[ grep { !/tmp/ } map { "$_" } @$_ ]});
+
+		my @rec;
+		my $pc_dir = dir($dir);
+		$pc_dir->recurse(
+			callback => sub { push @rec, path($_[0]) if $_[0] !~ /tmp/ and -f $_[0] },
+			depthfirst => 0,
+			preorder => 1
+		);
+
+		ok( !$_->is_done, "not done" ) for $paths, $strings;
+
+		my @all = $strings->all;
+
+		ok( $_->is_done, "done" ) for $paths, $strings;
+
+		is_deeply(
+			[ sort @all ],
+			[ sort @rec ],
+			"breadth first traversal path set",
+		);
+
+		is_deeply(
+			\@all,
+			\@rec,
+			"breadth first traversal order",
+		);
+	}
+}
+
+done_testing;


### PR DESCRIPTION
Hi, I've added `Path::Tiny` support for `Data::Stream::Bulk`. The implementation (code and tests) is a copycat of `Path::Class` variant. The most visible difference is the fact that `Path::Tiny` always cleans the stringified object, e.g. `./Changes` vs. `Changes`.

This PR is part of my [advent quest](https://questhub.io/realm/perl/quest/547b4202070ccf750d00010e).

Cheers,
Sergey.
